### PR TITLE
Potential fix for code scanning alert no. 5: Reflected cross-site scripting

### DIFF
--- a/scdms-backend/package.json
+++ b/scdms-backend/package.json
@@ -35,7 +35,8 @@
     "showdown": "^2.1.0",
     "swagger-ui-express": "^5.0.0",
     "typescript": "^5.3.3",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@flydotio/dockerfile": "^0.5.0",

--- a/scdms-backend/src/api/lessons.ts
+++ b/scdms-backend/src/api/lessons.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express"
 import passport from "passport";
 import fs from "fs"
 import { convert } from "html-to-text"
+import escape from "escape-html";
 import { fetchLessonHTML } from "../lessons/crawl.js";
 import { lessonExists, lessonFetch, lessonFetchByCourse, lessonInsert } from "../lessons/db.js";
 import { courseFetchIDBySlug } from "../courses/db.js";
@@ -21,7 +22,7 @@ router.get("/:course/:lesson", async (req: Request, res: Response) => {
     const { course, lesson } = req.params;
     const dbLesson = await lessonFetch(course, Number(lesson) || 1);
 
-    if (!dbLesson) return res.status(404).send(`<h1>No Lesson Found for ${course}/${lesson}</h1>`)
+    if (!dbLesson) return res.status(404).send(`<h1>No Lesson Found for ${escape(course)}/${escape(lesson)}</h1>`)
 
     if (req.query.raw == "true") return res.header("Content-Type", "text/plain; charset=utf-8").status(200).end(convert(dbLesson.data))
 


### PR DESCRIPTION
Potential fix for [https://github.com/simplified-coding/scdms/security/code-scanning/5](https://github.com/simplified-coding/scdms/security/code-scanning/5)

The proper way to fix this problem is to escape or encode user-supplied input (`course` and `lesson` in this context) before reflecting it back into the HTML response. The best way, given the use of Node.js/TypeScript, is to use a well-tested library such as `escape-html` to encode dynamic content for safe inclusion in HTML pages. This avoids introducing XSS vulnerabilities while preserving existing functionality.

Specifically:
- Add an import for `escape-html`.
- Escape both `course` and `lesson` in the error message at line 24 when interpolating into the HTML string:  
  `<h1>No Lesson Found for ${escape(course)}/${escape(lesson)}</h1>`

Only lines inside scdms-backend/src/api/lessons.ts need changes. Add the import at the top, and update the error message line accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
